### PR TITLE
008-feat: Migrate Events and Functions from jQuery to JS ES6 

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Your Page Title</title>
-    <script src="https://code.jquery.com/jquery-2.0.0.min.js"></script>
     <script src="src/js/bigfoot.js"></script>
     <link rel = "stylesheet" href="dist/bigfoot-default.css">
 </head>
@@ -30,11 +29,11 @@
     <script>
         function getCurrentDateTime() {
             var currentDateTime = new Date();
-            return currentDateTime.toLocaleString(); 
+            return currentDateTime.toLocaleString();  // Formats date and time as a string
         }
-        
-        $('#current-date-time').text(getCurrentDateTime());
 
+        // Insert current date and time into the footnote
+        document.getElementById('current-date-time').textContent = getCurrentDateTime();
 
         const newsHeadlines = [
             "New AI breakthrough in healthcare industry.",
@@ -43,17 +42,16 @@
         ];
 
         function displayNews() {
-            const newsList = $('#news-list');
-                newsHeadlines.forEach(function(news) {
-                $('<li></li>').text(news).appendTo(newsList);
+            const newsList = document.getElementById('news-list');
+            newsHeadlines.forEach(function(news) {
+                var listItem = document.createElement('li');
+                listItem.textContent = news;
+                newsList.appendChild(listItem);
             });
         }
-        displayNews();
 
         // Initialize Bigfoot plugin
-        bigfoot({
-            animationDuration: 3000,
-        });
+        bigfoot();
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <title>Your Page Title</title>
     <script src="src/js/bigfoot.js"></script>
     <link rel = "stylesheet" href="src/styles/bigfoot.css">
+    <link rel = "stylesheet" href="src/styles/bigfoot-variables.css">
+    
 </head>
 <body>
     <p>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Your Page Title</title>
     <script src="src/js/bigfoot.js"></script>
-    <link rel = "stylesheet" href="dist/bigfoot-default.css">
+    <link rel = "stylesheet" href="src/styles/bigfoot.css">
 </head>
 <body>
     <p>
@@ -43,12 +43,14 @@
 
         function displayNews() {
             const newsList = document.getElementById('news-list');
-            newsHeadlines.forEach(function(news) {
+            newsHeadlines.forEach((news) => {
                 var listItem = document.createElement('li');
                 listItem.textContent = news;
                 newsList.appendChild(listItem);
             });
         }
+        //calling the display news
+        displayNews();
 
         // Initialize Bigfoot plugin
         bigfoot();

--- a/src/js/bigfoot.js
+++ b/src/js/bigfoot.js
@@ -1,5 +1,6 @@
 (function() {
     const bigfoot = (options) => {
+
         const defaults = {
           actionOriginalFN: "hide",
           activateCallback: () => {},
@@ -204,33 +205,574 @@
         
             return footnoteHTML.replace(regex, "").replace("[]", "");
         };
-      
+
+        /************ EVENT HANDLERS *************/
+
+        const buttonHover = (event) => {
+            if (settings.activateOnHover) {
+                const buttonHovered = event.target.closest(".bigfoot-footnote__button");
+                const dataIdentifier = `[data-footnote-identifier='${buttonHovered.getAttribute("data-footnote-identifier")}']`;
+                
+                if (buttonHovered.classList.contains("is-active")) {
+                    return;
+                }
+                
+                buttonHovered.classList.add("is-hover-instantiated");
+                
+                if (!settings.allowMultipleFN) {
+                    const otherPopoverSelector = `.bigfoot-footnote:not(${dataIdentifier})`;
+                    removePopovers(otherPopoverSelector);
+                }
+                
+                createPopover(`.bigfoot-footnote__button${dataIdentifier}`).classList.add("is-hover-instantiated");
+            }
+        };
+        
+
+        const touchClick = (event) => {
+            const target = event.target;
+            const nearButton = target.closest(".bigfoot-footnote__button");
+            const nearFootnote = target.closest(".bigfoot-footnote");
+        
+            if (nearButton) {
+                event.preventDefault();
+                clickButton(nearButton);
+            } else if (!nearFootnote) {
+                if (document.querySelector(".bigfoot-footnote")) {
+                    removePopovers();
+                }
+            }
+        };
+        
+        const clickButton = function(button) {
+            console.log('inside click button');
+            let dataIdentifier;
+            button.blur();
+            dataIdentifier = `data-footnote-identifier='${button.getAttribute("data-footnote-identifier")}'`;
+        
+            if (button.classList.contains("changing")) {
+                return;
+            } else if (!button.classList.contains("is-active")) {
+                button.classList.add("changing");
+                setTimeout(function() {
+                    button.classList.remove("changing");
+                }, settings.popoverCreateDelay);
+        
+                createPopover(`.bigfoot-footnote__button[${dataIdentifier}]`);
+                button.classList.add("is-click-instantiated");
+        
+                if (!settings.allowMultipleFN) {
+                    removePopovers(`.bigfoot-footnote:not([${dataIdentifier}])`);
+                }
+            } 
+            else {
+                if (!settings.allowMultipleFN) {
+                    removePopovers();
+                } else {
+                    removePopovers(`.bigfoot-footnote[${dataIdentifier}]`);
+                }
+            }
+        };
+
+        const escapeKeypress = function(event) {
+            if (event.keyCode === 27) {
+              return removePopovers();
+            }
+        };
+        
+        const unhoverFeet = (e) => {
+            if (settings.deleteOnUnhover && settings.activateOnHover) {
+                return setTimeout(() => {
+                    const target = e.target.closest(".bigfoot-footnote, .bigfoot-footnote__button");
+                    if (!document.querySelector(".bigfoot-footnote__button:hover, .bigfoot-footnote:hover")) {
+                        return removePopovers();
+                    }
+                }, settings.hoverDelay);
+            }
+        };
+        
+
+        var bindScrollHandler = function() {
+            if (!settings.preventPageScroll) {
+              return this;
+            }
+            
+            this.addEventListener("DOMMouseScroll", function(event) { scrollHandler(event, this); });
+            this.addEventListener("mousewheel", function(event) { scrollHandler(event, this); });
+          
+            return this;
+        };
+
+        var scrollHandler = function(event, el) {
+            var popover = el.closest(".bigfoot-footnote");
+            var scrollTop = el.scrollTop;
+            var scrollHeight = el.scrollHeight;
+            var height = parseInt(getComputedStyle(el).height);
+            
+            if (scrollTop > 0 && scrollTop < 10) {
+              popover.classList.add("is-scrollable");
+            }
+            
+            if (!popover.classList.contains("is-scrollable")) {
+              return;
+            }
+          
+            var delta = event.type === "DOMMouseScroll" ? event.detail * -40 : event.wheelDelta;
+            var up = delta > 0;
+          
+            var prevent = function() {
+              event.stopPropagation();
+              event.preventDefault();
+              return false;
+            };
+          
+            if (!up && -delta > scrollHeight - height - scrollTop) {
+              el.scrollTop = scrollHeight;
+              popover.classList.add("is-fully-scrolled");
+              return prevent();
+            } else if (up && delta > scrollTop) {
+              el.scrollTop = 0;
+              popover.classList.remove("is-fully-scrolled");
+              return prevent();
+            } else {
+              popover.classList.remove("is-fully-scrolled");
+            }
+        };
+
+        const repositionFeet = function(e) {
+            if (settings.positionContent) {
+                let type = e ? e.type : "resize";
+        
+                document.querySelectorAll(".bigfoot-footnote").forEach(footnote => {
+                    // Retrieve dimensions and positioning details
+                    let identifier = footnote.getAttribute("data-footnote-identifier");
+                    let contentWrapper = footnote.querySelector(".bigfoot-footnote__content");
+                    let button = document.querySelector(`.bigfoot-footnote__button[data-footnote-identifier='${identifier}']`);
+                    let roomLeft = roomCalc(button);
+                    let marginSize = parseFloat(getComputedStyle(footnote).marginTop);
+                    let maxHeightInCSS = parseFloat(footnote.getAttribute("data-bigfoot-max-height"));
+                    let totalHeight = 2 * marginSize + footnote.offsetHeight;
+                    let maxHeightOnScreen = 10000;
+        
+                    // Determine position (top or bottom)
+                    let positionOnTop = roomLeft.bottomRoom < totalHeight && roomLeft.topRoom > roomLeft.bottomRoom;
+                    let lastState = popoverStates[identifier];
+                    console.log('pos on top:',positionOnTop);
+                    console.log('lastState',lastState);
+                    // Update classes and max heights
+                    if (positionOnTop) {
+                        if (lastState !== "top") {
+                            popoverStates[identifier] = "top";
+                            footnote.classList.add("is-positioned-top");
+                            footnote.classList.remove("is-positioned-bottom");
+                            footnote.style.transformOrigin = `${roomLeft.leftRelative * 100}% 100%`;
+                        }
+                        maxHeightOnScreen = roomLeft.topRoom - marginSize - 15;
+                    } else {
+                        if (lastState !== "bottom" || lastState === "init") {
+                            popoverStates[identifier] = "bottom";
+                            footnote.classList.remove("is-positioned-top");
+                            footnote.classList.add("is-positioned-bottom");
+                            footnote.style.transformOrigin = `${roomLeft.leftRelative * 100}% 0%`;
+                        }
+                        maxHeightOnScreen = roomLeft.bottomRoom - marginSize - 15;
+                    }
+        
+                    contentWrapper.style.maxHeight = `${Math.min(maxHeightOnScreen, maxHeightInCSS)}px`;
+                    thisElement = footnote;
+                    // Resize handling
+                    if (type === "resize") {
+                        // Get maxWidthInCSS from the data attribute "bigfoot-max-width"
+                        const maxWidthInCSS = parseFloat(thisElement.getAttribute("bigfoot-max-width"));
+                        
+                        // Select the main wrapper for the footnote
+                        const mainWrap = thisElement.querySelector(".bigfoot-footnote__wrapper");
+                      
+                        // Set maxWidth initially based on the CSS value
+                        let maxWidth = maxWidthInCSS;
+                      
+                        // If the maxWidth is defined as a relative value (<= 1)
+                        if (maxWidthInCSS <= 1) {
+                          const relativeToWidth = (function() {
+                            let userSpecifiedRelativeElWidth = 10000;
+                            
+                            // Check if settings specify an element to calculate the relative width against
+                            if (settings.maxWidthRelativeTo) {
+                              const relativeElement = document.querySelector(settings.maxWidthRelativeTo);
+                              if (relativeElement) {
+                                userSpecifiedRelativeElWidth = relativeElement.offsetWidth;
+                              }
+                            }
+                      
+                            // Use the minimum width between the window's inner width and the relative element width
+                            return Math.min(window.innerWidth, userSpecifiedRelativeElWidth);
+                          })();
+                      
+                          // Calculate maxWidth based on relative width
+                          maxWidth = relativeToWidth * maxWidthInCSS;
+                        }
+                      
+                        // Ensure maxWidth doesn't exceed the content width plus 1
+                        const contentElement = thisElement.querySelector(".bigfoot-footnote__content");
+                        console.log(contentElement.style);
+                        maxWidth = Math.min(maxWidth, contentElement.offsetWidth + 1);
+                      
+                        // Set the max-width of the main wrapper
+                        mainWrap.style.maxWidth = `${maxWidth}px`;
+                      
+                        // Calculate the left position and set it
+                        const buttonMarginLeft = parseFloat(window.getComputedStyle(button).marginLeft);
+                        const buttonOuterWidth = button.offsetWidth;
+                        thisElement.style.left = `${(-roomLeft.leftRelative * maxWidth + buttonMarginLeft + buttonOuterWidth / 2)}px`;
+                      
+                        // Call positionTooltip with the current element and leftRelative value
+                        positionTooltip(thisElement, roomLeft.leftRelative);
+                      }
+                      
+        
+                    // Scroll handling
+                    if (footnote.offsetHeight < contentWrapper.scrollHeight) {
+                        footnote.classList.add("is-scrollable");
+                    }
+                });
+            }
+        };
+
+        /************ AUXILLIARY FUNCTIONS *************/
+
+        const calculatePixelDimension = function(dim, el) {
+            if (dim === "none") {
+              dim = 10000; // Very large value for "none"
+            } else if (dim.includes("rem")) {
+              dim = parseFloat(dim) * baseFontSize();
+            } else if (dim.includes("em")) {
+              dim = parseFloat(dim) * parseFloat(getComputedStyle(el).fontSize);
+            } else if (dim.includes("px")) {
+              dim = parseFloat(dim);
+              if (dim <= 60) {
+                dim = dim / parseFloat(getComputedStyle(el.parentNode).width);
+              }
+            } else if (dim.includes("%")) {
+              dim = parseFloat(dim) / 100;
+            }
+            
+            return dim;
+        };
+
+        const baseFontSize = () => {
+            const el = document.createElement("div");
+            el.style.cssText = "display:inline-block;padding:0;line-height:1;position:absolute;visibility:hidden;font-size:1em;";
+            el.appendChild(document.createElement("M"));
+            document.body.appendChild(el);
+            
+            const size = el.offsetHeight;
+            document.body.removeChild(el);
+            
+            return size;
+          };
+          
+
+        const addBreakpoint = (size, trueCallback, falseCallback, deleteDelay = settings.popoverDeleteDelay, removeOpen = true) => {
+            let mql, minMax, s, query;
+            
+            if (typeof size === "string") {
+                s = size.toLowerCase() === "iphone" ? "<320px" : size.toLowerCase() === "ipad" ? "<768px" : size;
+                minMax = s.charAt(0) === ">" ? "min" : s.charAt(0) === "<" ? "max" : null;
+                query = minMax ? `(${minMax}-width: ${s.substring(1)})` : s;
+                mql = window.matchMedia(query);
+            } else {
+                mql = size;
+            }
+        
+            if (mql.media && mql.media === "invalid") {
+                return {
+                    added: false,
+                    mq: mql,
+                    listener: null
+                };
+            }
+        
+            const trueDefaultPositionSetting = minMax === "min";
+            const falseDefaultPositionSetting = minMax === "max";
+        
+            trueCallback = trueCallback || makeDefaultCallbacks(removeOpen, deleteDelay, trueDefaultPositionSetting, ($popover) => {
+                $popover.classList.add("is-bottom-fixed");
+            });
+        
+            falseCallback = falseCallback || makeDefaultCallbacks(removeOpen, deleteDelay, falseDefaultPositionSetting, () => {});
+        
+            const mqListener = (mq) => {
+                if (mq.matches) {
+                    trueCallback(removeOpen, bigfoot);
+                } else {
+                    falseCallback(removeOpen, bigfoot);
+                }
+            };
+        
+            mql.addEventListener('change', mqListener);
+            mqListener(mql);
+        
+            settings.breakpoints[size] = {
+                added: true,
+                mq: mql,
+                listener: mqListener
+            };
+        
+            return settings.breakpoints[size];
+        };
+        
+        const makeDefaultCallbacks = (removeOpen, deleteDelay, position, callback) => {
+            return (removeOpen, bigfoot) => {
+              let closedPopovers;
+          
+              if (removeOpen) {
+                closedPopovers = bigfoot.close();
+                bigfoot.updateSetting("activateCallback", callback);
+              }
+          
+              setTimeout(() => {
+                bigfoot.updateSetting("positionContent", position);
+                if (removeOpen) {
+                  bigfoot.activate(closedPopovers);
+                }
+              }, deleteDelay);
+            };
+        };
+        
+        const removeBreakpoint = (target, callback) => {
+            let mqFound = false;
+            let b;
+            
+            if (typeof target === "string") {
+              mqFound = settings.breakpoints[target] !== undefined;
+            } else {
+              for (b in settings.breakpoints) {
+                if (settings.breakpoints.hasOwnProperty(b) && settings.breakpoints[b].mq === target) {
+                  mqFound = true;
+                  break; // Stop the loop when the target is found
+                }
+              }
+            }
+          
+            if (mqFound) {
+              const breakpoint = settings.breakpoints[b || target];
+              const listener = callback || breakpoint.listener;
+          
+              listener({ matches: false });
+              breakpoint.mq.removeEventListener('change', breakpoint.listener);
+              delete settings.breakpoints[b || target];
+            }
+          
+            return mqFound;
+          };
+          
+        const getSetting = (setting) => {
+            return settings[setting];
+        };
+        
+        const updateSetting = (newSettings, value) => {
+            let oldValue;
+          
+            if (typeof newSettings === "string") {
+              oldValue = settings[newSettings];
+              settings[newSettings] = value;
+            } else {
+              oldValue = {};
+              for (const prop in newSettings) {
+                if (newSettings.hasOwnProperty(prop)) {
+                  oldValue[prop] = settings[prop];
+                  settings[prop] = newSettings[prop];
+                }
+              }
+            }
+          
+            return oldValue;
+          };
+          
+          
+
+        const positionTooltip = function(popover, leftRelative = 0.5) {
+            const tooltip = popover.querySelector(".bigfoot-footnote__tooltip");
+            if (tooltip) {
+                tooltip.style.left = `${leftRelative * 100}%`;
+            }
+        };
+        
+
+        const roomCalc = function(el) {
+            let elStyles = getComputedStyle(el);
+            let elLeftMargin = parseFloat(elStyles.marginLeft);
+            let elWidth = el.offsetWidth - elLeftMargin;
+            let elHeight = el.offsetHeight;
+        
+            let rect = el.getBoundingClientRect();
+            let w = viewportDetails();
+        
+            let topRoom = rect.top + elHeight / 2;
+            let leftRoom = rect.left + elWidth / 2;
+        
+            return {
+                topRoom: topRoom,
+                bottomRoom: w.height - topRoom,
+                leftRoom: leftRoom,
+                rightRoom: w.width - leftRoom,
+                leftRelative: leftRoom / w.width,
+                topRelative: topRoom / w.height
+            };
+        };
+
+        const viewportDetails = function() {
+            return {
+              width: window.innerWidth,
+              height: window.innerHeight,
+              scrollX: window.pageXOffset || document.documentElement.scrollLeft,
+              scrollY: window.pageYOffset || document.documentElement.scrollTop
+            };
+          };    
+        
+
+        /************ CREATING AND REMOVING POPOVERS *************/
+
+        const createPopover = function(selector) {
+            let buttons, popoversCreated = [];
+        
+            // Determine button elements based on selector and settings
+            if (typeof selector !== "string" && settings.allowMultipleFN) {
+                buttons = selector;
+            } else if (typeof selector !== "string") {
+                buttons = [selector[0]]; // Convert first element to array
+            } else if (settings.allowMultipleFN) {
+                buttons = document.querySelectorAll(selector);
+            } else {
+                buttons = [document.querySelector(selector).closest(".bigfoot-footnote__button")];
+            }
+            
+            // Process each button
+            buttons.forEach((button) => {
+                let content, contentContainer;
+                
+                try {
+                    content = settings.contentMarkup
+                        .replace(/\{\{FOOTNOTENUM\}\}/g, button.getAttribute("data-footnote-number"))
+                        .replace(/\{\{FOOTNOTEID\}\}/g, button.getAttribute("data-footnote-identifier"))
+                        .replace(/\{\{FOOTNOTECONTENT\}\}/g, button.getAttribute("data-bigfoot-footnote"))
+                        .replace(/\&gtsym\;/g, "&gt;")
+                        .replace(/\&ltsym\;/g, "&lt;");
+                    
+                    content = replaceWithReferenceAttributes(content, "BUTTON", button);
+                    console.log(content);
+                } finally {
+                    // Create and configure the content element
+                    const range = document.createRange();
+                    const contentElement = range.createContextualFragment(content).firstElementChild; 
+                    //content has "<aside>...</aside>"; contextual fragment creates a fragment out of the content string and firstelement generates ref to the actual element
+                    //this method avoids creating a <div> and then adding content to its innerHTML
+                    console.log(contentElement);
+                    try {
+                        settings.activateCallback(contentElement, button);
+                    } catch (error) { console.log('hello')}
+        
+                    // Insert the contentElement after the button
+                    button.insertAdjacentElement('afterend', contentElement);
+                    popoverStates[button.getAttribute("data-footnote-identifier")] = "init";
+                    console.log(popoverStates);
+                    const maxWidth = calculatePixelDimension(getComputedStyle(contentElement).maxWidth, contentElement);
+                    contentElement.setAttribute("bigfoot-max-width", maxWidth);
+                    contentElement.style.maxWidth = "10000px"; // Set large max-width for animation
+                    contentElement.style.transitionDuration = settings.animationDuration + "ms";
+        
+                    // Configure the content container
+                    contentContainer = contentElement.querySelector(".bigfoot-footnote__content");
+                    const maxHeight = calculatePixelDimension(getComputedStyle(contentContainer).maxHeight, contentContainer);
+                    contentElement.setAttribute("data-bigfoot-max-height", maxHeight);
+        
+                    repositionFeet();
+                    button.classList.add("is-active");
+                    
+                    // Bind scroll handler to content container
+                    bindScrollHandler.call(contentContainer);
+        
+                    // Track created popovers
+                    popoversCreated.push(contentElement);
+                }
+            });
+            setTimeout(() => {
+                popoversCreated.forEach(popover => { popover.classList.add("is-active") });
+            }, settings.popoverCreateDelay);
+            return popoversCreated;
+        }
+
+        const removePopovers = (footnotes = ".bigfoot-footnote", timeout = settings.popoverDeleteDelay) => {
+            let buttonsClosed = [];
+            
+            const footnoteElements = document.querySelectorAll(footnotes);
+            footnoteElements.forEach(footnote => {
+                const footnoteID = footnote.getAttribute("data-footnote-identifier");
+                const linkedButton = document.querySelector(`.bigfoot-footnote__button[data-footnote-identifier='${footnoteID}']`);
+        
+                if (!linkedButton.classList.contains("changing")) {
+                    buttonsClosed.push(linkedButton);
+                    linkedButton.classList.remove("is-active", "is-hover-instantiated", "is-click-instantiated");
+                    linkedButton.classList.add("changing");
+        
+                    footnote.classList.remove("is-active");
+                    footnote.classList.add("disapearing");
+        
+                    setTimeout(() => {
+                        footnote.remove();
+                        delete popoverStates[footnoteID];
+                        linkedButton.classList.remove("changing");
+                    }, timeout);
+                }
+            });
+        
+            return buttonsClosed;
+        };        
+
+        
+        /************ MAPPING EVENT LISTENERS TO EVENT HANDLERS *************/
+
         const addEventListeners = () => {
-            document.addEventListener('mouseenter', buttonHover, true);
-            document.addEventListener('touchend', touchClick);
-            document.addEventListener('mouseout', unhoverFeet);
-            document.addEventListener('keyup', escapeKeypress);
-            window.addEventListener('scroll', repositionFeet);
-            window.addEventListener('resize', repositionFeet);
-            document.addEventListener('gestureend', repositionFeet);
+            document.addEventListener("mouseenter", (event) => {
+                if (event.target.matches(".bigfoot-footnote__button")) {
+                  buttonHover(event);
+                }
+              });
+            
+              document.addEventListener("touchend", touchClick);
+              document.addEventListener("click", touchClick);
+            
+              document.addEventListener("mouseout", (event) => {
+                if (event.target.classList.contains("is-hover-instantiated")) {
+                  unhoverFeet(event);
+                }
+              });
+            
+              document.addEventListener("keyup", escapeKeypress);
+              window.addEventListener("scroll", repositionFeet);
+              window.addEventListener("resize", repositionFeet);
+            
+              window.addEventListener("gestureend", () => {
+                repositionFeet();
+              });
         };
       
         document.addEventListener('DOMContentLoaded', () => {
             footnoteInit();
-        //   addEventListeners();
+            addEventListeners();
         });
       
         return {
-        //   removePopovers,
-        //   close: removePopovers,
-        //   createPopover,
-        //   activate: createPopover,
-        //   repositionFeet,
-        //   reposition: repositionFeet,
-        //   addBreakpoint,
-        //   removeBreakpoint,
-        //   getSetting,
-        //   updateSetting
+            removePopovers: removePopovers,
+            close: removePopovers,
+            createPopover: createPopover,
+            activate: createPopover,
+            repositionFeet: repositionFeet,
+            reposition: repositionFeet,
+            addBreakpoint: addBreakpoint,
+            removeBreakpoint: removeBreakpoint,
+            getSetting: getSetting,
+            updateSetting: updateSetting
         };
     };    
 

--- a/src/js/bigfoot.js
+++ b/src/js/bigfoot.js
@@ -292,7 +292,7 @@
         };
         
 
-        var bindScrollHandler = function() {
+        const bindScrollHandler = function() {
             if (!settings.preventPageScroll) {
               return this;
             }
@@ -303,11 +303,11 @@
             return this;
         };
 
-        var scrollHandler = function(event, el) {
-            var popover = el.closest(".bigfoot-footnote");
-            var scrollTop = el.scrollTop;
-            var scrollHeight = el.scrollHeight;
-            var height = parseInt(getComputedStyle(el).height);
+        const scrollHandler = function(event, el) {
+            let popover = el.closest(".bigfoot-footnote");
+            let scrollTop = el.scrollTop;
+            let scrollHeight = el.scrollHeight;
+            let height = parseInt(getComputedStyle(el).height);
             
             if (scrollTop > 0 && scrollTop < 10) {
               popover.classList.add("is-scrollable");
@@ -317,10 +317,10 @@
               return;
             }
           
-            var delta = event.type === "DOMMouseScroll" ? event.detail * -40 : event.wheelDelta;
-            var up = delta > 0;
+            let delta = event.type === "DOMMouseScroll" ? event.detail * -40 : event.wheelDelta;
+            let up = delta > 0;
           
-            var prevent = function() {
+            const prevent = function() {
               event.stopPropagation();
               event.preventDefault();
               return false;

--- a/src/styles/Variants/bigfoot-bottom.css
+++ b/src/styles/Variants/bigfoot-bottom.css
@@ -1,0 +1,48 @@
+/* A footnote popover that, unlike the default, is not positioned relative to
+   the button, but instead is positioned at the bottom of the page. This popover
+   transitions with a simple slide in from the bottom. 
+   This style requires that the `positionContent` option of bigfoot is set to false.
+   @author Rashi Bhansali
+*/
+
+.bigfoot-footnote {
+    /* POSITIONING */
+    position: fixed;
+    bottom: 0;
+    top: auto;
+    left: 0;
+    right: auto;
+    transform: translateY(100%);
+  
+    /* DISPLAY AND SIZING */
+    width: 100%;
+    margin: 0;
+  
+    /* BACKDROP */
+    border-radius: 0;
+    opacity: 1;
+    border-width: 1px 0 0;
+  
+    /* TRANSITIONS */
+    transition: transform 0.3s ease;
+  }
+  
+  .bigfoot-footnote.is-active {
+    transform: translateY(0);
+  }
+  
+  .bigfoot-footnote__wrapper {
+    margin: 0 0 0 50%;
+    transform: translateX(-50%);
+    max-width: 100%;
+  }
+  
+  .bigfoot-footnote__wrapper,
+  .bigfoot-footnote__content {
+    border-radius: 0;
+  }
+  
+  .bigfoot-footnote__tooltip {
+    display: none;
+  }
+  

--- a/src/styles/Variants/bigfoot-number.css
+++ b/src/styles/Variants/bigfoot-number.css
@@ -1,0 +1,45 @@
+/* A button that has no ellipse, but instead shows the footnote's number on the
+   page. Note that the number will be reset to 1 depending on the selector passed
+   to bigfoot's `numberResetSelector` option.
+   @author Rashi Bhansali
+*/
+
+.bigfoot-footnote__button {
+    position: relative;
+    height: var(--button-height); /* Assuming $button-height is defined as a CSS variable */
+    width: 1.5em;
+    border-radius: calc(var(--button-height) / 2); /* Assuming $button-height is defined as a CSS variable */
+  
+  }
+  
+  .bigfoot-footnote__button:after {
+    /* CONTENT */
+    content: attr(data-footnote-number);
+  
+    /* POSITION */
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  
+    /* DISPLAY AND SIZING */
+    display: block;
+  
+    /* TEXT */
+    font-size: calc(var(--button-height) * 0.6); /* Assuming $button-height is defined as a CSS variable */
+    font-weight: bold;
+    color: rgba(var(--button-color), 0.5); /* Assuming $button-color is defined as a CSS variable */
+  
+    /* TRANSITIONS */
+    transition: color var(--popover-transition-default-duration) var(--popover-transition-default-timing-function); /* Assuming transition values are defined as CSS variables */
+  }
+  
+  .bigfoot-footnote__button:hover:after,
+  .bigfoot-footnote__button.is-active:after {
+    color: white;
+  }
+  
+  .bigfoot-footnote__button__circle {
+    display: none;
+  }
+  

--- a/src/styles/bigfoot-variables.css
+++ b/src/styles/bigfoot-variables.css
@@ -1,0 +1,102 @@
+
+/* These are the key variables for styling the popover.
+   Just set the variable to none if you don't want that styling. */
+
+/* KEY VARIABLES
+   ========================================================================== */
+
+/* POPOVER STYLES */
+:root {
+    --popover-width: 22em;  /* Ideal width of the popover */
+    --popover-max-width: 90%;  /* Best as a % to accommodate smaller viewports */
+    --popover-max-height: 15em;  /* Maximum size of the content area */
+    --popover-color-background: rgb(250, 250, 250);  /* Color of the popover background */
+    --popover-border-radius: 0.5em;  /* Radius of the corners of the popover */
+    --popover-border: 1px solid rgb(195, 195, 195);  /* Border of the popover/tooltip */
+    --popover-inactive-opacity: 0;  /* Opacity of the popover when instantiated/deactivating */
+    --popover-active-opacity: 0.97;  /* Opacity of the popover when active */
+    --popover-box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.3);  /* Sets the box shadow under the popover/tooltip */
+    --popover-bottom-position: auto;  /* Sets the bottom position of the popover */
+    --popover-left-position: auto;  /* Sets the left position of the popover */
+    --popover-tooltip-size: 1.3em;  /* Sets the side lengths of the tooltip */
+    --popover-scroll-indicator-width: 0.625em;  /* The width of the scroll indicator */
+    --popover-scroll-indicator-aspect-ratio: calc(15 / 12);  /* The ratio of the height over the width of the scroll indicator */
+    --popover-scroll-indicator-opacity: 0.1;  /* The active opacity of scroll indicators */
+    --popover-initial-transform-state: scale(0.1) translateZ(0);  /* The initial transform state for the popover */
+    --popover-active-transform-state: scale(1) translateZ(0);  /* The transform state for the popover once it is fully activated */
+  
+    /* OPTIONAL ELEMENTS */
+    /* ========================================================================== */
+  
+    --popover-include-tooltip: true;  /* Adds a tooltip pointing to the footnote button */
+    --popover-include-scroll-indicator: true;  /* Adds an ellipsis at the bottom of scrollable popovers */
+    --popover-include-scrolly-fades: true;  /* Fades content in on scrollable popovers */
+    --popover-scroll-indicator-icon: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTJweCIgaGVpZ2h0PSIxNXB4IiB2aWV3Qm94PSIwIDAgMTIgMTUiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pbllNaW4iPgogICAgPGcgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9IkFycm93IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxLjAwMDAwMCwgMS4wMDAwMDApIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJzcXVhcmUiPgogICAgICAgICAgICA8cGF0aCBkPSJNNSwwIEw1LDExLjUiIGlkPSJMaW5lIj48L3BhdGg+CiAgICAgICAgICAgIDxwYXRoIGQ9Ik0wLjUsNy41IEw1LjAyNzY5Mjc5LDEyLjAyNzY5MjgiIGlkPSJMaW5lIj48L3BhdGg+CiAgICAgICAgICAgIDxwYXRoIGQ9Ik00LjUsNy41IEw5LjAyNzY5Mjc5LDEyLjAyNzY5MjgiIGlkPSJMaW5lLTIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDcuMDAwMDAwLCAxMC4wMDAwMDApIHNjYWxlKC0xLCAxKSB0cmFuc2xhdGUoLTcuMDAwMDAwLCAtMTAuMDAwMDAwKSAiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPgo=");  /* Icon for scroll indicator */
+  
+    /* OTHER VARIABLES */
+    /* ========================================================================== */
+  
+    --popover-margin-top: 0.1em;  /* Margin at the top of the popover */
+    --popover-padding-content-horizontal: 1.3em;  /* Horizontal padding for popover content */
+    --popover-padding-content-top: 1.1em;  /* Top padding for popover content */
+    --popover-padding-content-bottom: 1.2em;  /* Bottom padding for popover content */
+    --popover-z-index: 10;  /* Set the base so that it's above the other body children */
+    --popover-initial-transform-origin: 50% 0;  /* Transform origin for the popover */
+  
+    /* POPOVER CONTENT WRAPPER */
+    /* ========================================================================== */
+  
+    --popover-content-color-background: var(--popover-color-background);  /* Background color for the popover content */
+    --popover-content-border-radius: var(--popover-border-radius);  /* Border radius for the popover content */
+  
+    /* OTHER POPOVER ELEMENTS */
+    /* ========================================================================== */
+  
+    --popover-tooltip-background: var(--popover-color-background);  /* Background color for the tooltip */
+    --popover-tooltip-radius: 0;  /* Radius for the tooltip */
+    --popover-scroll-indicator-bottom-position: 0.45em;  /* Bottom position for scroll indicators */
+    --popover-scrolly-fade-gradient-start-location: 50%;  /* Gradient start location for scrollable fades */
+    --popover-scroll-indicator-padding: calc((var(--popover-padding-content-horizontal) / 2) - (var(--popover-scroll-indicator-width / 2)));  /* Padding for scroll indicator */
+  
+    /* TRANSITIONS */
+    /* ========================================================================== */
+  
+    --popover-transition-default-duration: 0.25s;  /* Default duration for transitions */
+    --popover-scroll-indicator-transition-properties: opacity;  /* Transition properties for scroll indicator */
+    
+    /* Use none for areas you don't want to transition */
+    --popover-transition-properties: opacity, transform;  /* Transition properties for popover */
+    --popover-scroll-indicator-transition-properties: opacity;  /* Transition properties for scroll indicator */
+    --popover-scroll-up-transition-delay: 0.4s;  /* Delay for scrolling up transition */
+    --popover-transition-default-timing-function: ease;  /* Default timing function for transitions */
+
+    --button-height: 0.95em;  /* The total height of the button */
+    --button-width: auto;  /* The total button width (applies only if $button-apply-dimensions is true) */
+    --button-inner-circle-size: 0.25em;  /* Total height/width of the ellipsis circles */
+    --button-border-radius: 0.3em;  /* Border radius on the button itself */
+    --button-left-margin: 0.2em;  /* Margin between the button and the text to its left */
+    --button-right-margin: 0.1em;  /* Margin between the button and the text to its right */
+    --button-vertical-adjust: -0.1em;  /* Pushes the buttons along the vertical axis to align it with text as desired */
+    --button-inner-circle-left-margin: calc(1 * var(--button-inner-circle-size));  /* Space between the ellipsis circles */
+  
+    --button-color: rgb(110, 110, 110);  /* Background color of the button */
+    --button-hovered-color: var(--button-color);  /* Background color of the button when being hovered */
+    --button-activating-color: var(--button-color);  /* Background color of the button when being clicked */
+    --button-active-color: var(--button-color);  /* Background color of the button when active */
+    --button-standard-opacity: 0.2;  /* Opacity for when the button is just sittin' there */
+    --button-hovered-opacity: 0.5;  /* Opacity for when the button is being hovered over */
+    --button-activating-opacity: var(--button-hovered-opacity);  /* Opacity for when the button is being clicked */
+    --button-active-opacity: 1;  /* Opacity for when the button is active */
+    --button-active-style-delay: 0.1s;  /* Delay before applying .active styles; this can be used to match to the popover activation transition */
+  
+    --button-inner-circle-color: white;  /* Background color of the ellipsis circle */
+    --button-inner-circle-border: none;  /* Border of the ellipsis circle */
+  
+    /* OTHER VARIABLES */
+    /* ========================================================================== */
+  
+    --button-total-padding: calc(var(--button-height) - var(--button-inner-circle-size));  /* Total padding for the button */
+    --button-per-side-padding: calc(0.5 * var(--button-total-padding));  /* Padding on each side of the button */
+    --button-transition-properties: background-color;  /* Transition properties for the button */
+  }
+  

--- a/src/styles/bigfoot.css
+++ b/src/styles/bigfoot.css
@@ -1,3 +1,11 @@
+/*
+// The button that activates the footnote. By default, this will appear as a
+// flat button that has an ellipse contained inside of it.
+
+// @state .is-active            - The associated popover has been activated and is visible.
+// @author Rashi Bhansali
+*/
+
 .bigfoot-footnote__button {
     position: relative;
     z-index: 5;
@@ -41,7 +49,6 @@
     width: 0.25em;
     height: 0.25em;
     margin-right: 0.25em;
-    float: left;
 }
 .bigfoot-footnote__button__circle:last-child {
     margin-right: 0;
@@ -51,6 +58,8 @@
     position: relative;
     text-indent: 0;
 }
+
+/* Styles to restore the original footnote numbers and texts when the page is printed */
 @media not print {
     .footnote-print-only {
         display: none !important;
@@ -61,6 +70,24 @@
         display: none !important;
    }
 }
+
+/*
+// The popover for the footnote. This popover will be, by default, be sized and positioned
+// by the script. However, many of the sizes can be established in this stylesheet and
+// will be respected by the script. `max-width` will limit the width of the popover
+// relative to the viewport. `width` (on `bigfoot-footnote__wrapper`) will set the
+// absolute max width. Max height can be set via a `max-height` property
+// on `bigfoot-footnote__content`.
+
+// By default, the popover has a light gray background, a shadow for some depth,
+// rounded corners, and a tooltip pointing to the footnote button.
+
+// @state .is-active            - The popover has been activated and is visible.
+// @state .is-positioned-top    - The popover is above the button.
+// @state .is-positioned-bottom - The popover is below the button.
+// @state .is-scrollable        - The popover content is greater than the popover height.
+// @state .is-fully-scrolled    - The popover content is scrolled to the bottom. */
+
 .bigfoot-footnote {
     position: absolute;
     z-index: 10;

--- a/src/styles/bigfoot.css
+++ b/src/styles/bigfoot.css
@@ -1,0 +1,216 @@
+.bigfoot-footnote__button {
+    position: relative;
+    z-index: 5;
+    top: -0.1em;
+    box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    display: inline-block;
+    padding: 0.35em;
+    margin: 0 0.1em 0 0.2em;
+    border: none;
+    border-radius: 0.3em;
+    cursor: pointer;
+    background-color: rgba(110, 110, 110, 0.2);
+    backface-visibility: hidden;
+    font-size: 1rem;
+    line-height: 0;
+    vertical-align: middle;
+    text-decoration: none;
+    -webkit-font-smoothing: antialiased;
+    transition-property: background-color;
+    transition-duration: 0.25s;
+}
+.bigfoot-footnote__button:hover, .bigfoot-footnote__button:focus {
+    outline: none;
+    background-color: rgba(110, 110, 110, 0.5);
+}
+.bigfoot-footnote__button:active {
+    background-color: rgba(110, 110, 110, 0.5);
+}
+.bigfoot-footnote__button.is-active {
+    background-color: rgba(110, 110, 110, 1);
+    transition-delay: 0.1s;
+}
+.bigfoot-footnote__button:after {
+    content: '';
+    display: table;
+    clear: both;
+}
+.bigfoot-footnote__button__circle {
+    display: inline-block;
+    width: 0.25em;
+    height: 0.25em;
+    margin-right: 0.25em;
+    float: left;
+}
+.bigfoot-footnote__button__circle:last-child {
+    margin-right: 0;
+}
+.bigfoot-footnote__container {
+    display: inline-block;
+    position: relative;
+    text-indent: 0;
+}
+@media not print {
+    .footnote-print-only {
+        display: none !important;
+   }
+}
+@media print {
+    .bigfoot-footnote, .bigfoot-footnote__button {
+        display: none !important;
+   }
+}
+.bigfoot-footnote {
+    position: absolute;
+    z-index: 10;
+    top: 0;
+    left: 0;
+    display: inline-block;
+    box-sizing: border-box;
+    max-width: 90%;
+    margin: 1.9692388156em 0;
+    background: #fafafa;
+    opacity: 0;
+    border-radius: 0.5em;
+    border: 1px solid #c3c3c3;
+    box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.3);
+    line-height: 0;
+    transition-property: opacity, transform;
+    transition-duration: 0.25s;
+    transition-timing-function: ease;
+    transform: scale(0.1) translateZ(0);
+    transform-origin: 50% 0;
+}
+.bigfoot-footnote.is-positioned-top {
+    top: auto;
+    bottom: 0;
+}
+.bigfoot-footnote.is-active {
+    transform: scale(1) translateZ(0);
+    opacity: 0.97;
+}
+.bigfoot-footnote.is-bottom-fixed {
+    position: fixed;
+    bottom: 0;
+    top: auto;
+    left: 0;
+    right: auto;
+    transform: translateY(100%);
+    width: 100%;
+    margin: 0;
+    border-radius: 0;
+    opacity: 1;
+    border-width: 1px 0 0;
+    transition: transform 0.3s ease;
+}
+.bigfoot-footnote.is-bottom-fixed.is-active {
+    transform: translateY(0);
+}
+.bigfoot-footnote.is-bottom-fixed .bigfoot-footnote__wrapper {
+    margin: 0 0 0 50%;
+    transform: translateX(-50%);
+    max-width: 100%;
+}
+.bigfoot-footnote.is-bottom-fixed .bigfoot-footnote__wrapper, .bigfoot-footnote.is-bottom-fixed .bigfoot-footnote__content {
+    border-radius: 0;
+}
+.bigfoot-footnote.is-bottom-fixed .bigfoot-footnote__tooltip {
+    display: none;
+}
+.bigfoot-footnote.is-scrollable:after {
+    content: '';
+    position: absolute;
+    bottom: 0.3375em;
+    left: 0.3375em;
+    z-index: 14;
+    display: block;
+    height: 0.78125em;
+    width: 0.625em;
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTJweCIgaGVpZ2h0PSIxNXB4IiB2aWV3Qm94PSIwIDAgMTIgMTUiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pbllNaW4iPgogICAgPGcgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9IkFycm93IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxLjAwMDAwMCwgMS4wMDAwMDApIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJzcXVhcmUiPgogICAgICAgICAgICA8cGF0aCBkPSJNNSwwIEw1LDExLjUiIGlkPSJMaW5lIj48L3BhdGg+CiAgICAgICAgICAgIDxwYXRoIGQ9Ik0wLjUsNy41IEw1LjAyNzY5Mjc5LDEyLjAyNzY5MjgiIGlkPSJMaW5lIj48L3BhdGg+CiAgICAgICAgICAgIDxwYXRoIGQ9Ik00LjUsNy41IEw5LjAyNzY5Mjc5LDEyLjAyNzY5MjgiIGlkPSJMaW5lLTIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDcuMDAwMDAwLCAxMC4wMDAwMDApIHNjYWxlKC0xLCAxKSB0cmFuc2xhdGUoLTcuMDAwMDAwLCAtMTAuMDAwMDAwKSAiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPgo=");
+    background-size: cover;
+    opacity: 0.1;
+    transition-property: opacity;
+    transition-duration: 0.25s;
+    transition-timing-function: ease;
+}
+.bigfoot-footnote.is-scrollable .bigfoot-footnote__wrapper:before, .bigfoot-footnote.is-scrollable .bigfoot-footnote__wrapper:after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    z-index: 12;
+    left: 0;
+}
+.bigfoot-footnote.is-scrollable .bigfoot-footnote__wrapper:before {
+    top: -1px;
+    height: 1.1em;
+    border-radius: 0.5em 0.5em 0 0;
+    background-image: linear-gradient(to bottom, #fafafa 50%, rgba(250, 250, 250, 0) 100%);
+}
+.bigfoot-footnote.is-scrollable .bigfoot-footnote__wrapper:after {
+    bottom: -1px;
+    height: 1.2em;
+    border-radius: 0 0 0.5em 0.5em;
+    background-image: linear-gradient(to top, #fafafa 50%, rgba(250, 250, 250, 0) 100%);
+}
+.bigfoot-footnote.is-scrollable ::-webkit-scrollbar {
+    display: none;
+}
+.bigfoot-footnote.is-fully-scrolled:after, .bigfoot-footnote.is-fully-scrolled:before {
+    opacity: 0;
+    transition-delay: 0;
+}
+.bigfoot-footnote__wrapper {
+    position: relative;
+    z-index: 14;
+    width: 22em;
+    display: inline-block;
+    box-sizing: inherit;
+    overflow: hidden;
+    margin: 0;
+    background-color: #fafafa;
+    border-radius: 0.5em;
+    line-height: 0;
+}
+.bigfoot-footnote__content {
+    position: relative;
+    z-index: 8;
+    display: inline-block;
+    max-height: 15em;
+    padding: 1.1em 1.3em 1.2em;
+    box-sizing: inherit;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    background: #fafafa;
+    border-radius: 0.5em;
+    -webkit-font-smoothing: subpixel-antialiased;
+    line-height: normal;
+}
+.bigfoot-footnote__content img {
+    max-width: 100%;
+}
+.bigfoot-footnote__content *:last-child {
+    margin-bottom: 0 !important;
+}
+.bigfoot-footnote__content *:first-child {
+    margin-top: 0 !important;
+}
+.bigfoot-footnote__tooltip {
+    position: absolute;
+    z-index: 12;
+    box-sizing: border-box;
+    margin-left: -0.65em;
+    width: 1.3em;
+    height: 1.3em;
+    transform: rotate(45deg);
+    background: #fafafa;
+    border: 1px solid #c3c3c3;
+    box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.3);
+    border-top-left-radius: 0;
+}
+.is-positioned-bottom .bigfoot-footnote__tooltip {
+    top: -0.65em;
+}
+.is-positioned-top .bigfoot-footnote__tooltip {
+    bottom: -0.65em;
+}


### PR DESCRIPTION
- This is the **migration of events** like `click`, `hover` `scroll` and `resize` along with their corresponding **handlers** from Bigfoot.js in jQuery to JS ES6
- **Util functions** like `calculatePixelDimensions()`, `roomCalc()`, `positionTooltip()` etc. related to the positioning and sizing of the popovers have also been successfully moved to ES6 successfully. 
- Main methods like `createPopover()` and `removePopovers()`, have been moved to JS ES6. These methods are called every time a footnote is clicked or when the user clicks outside, respectively.

This would fix https://github.com/Shyam-Sundar-Bharathi/cse210-tinyfoot-team14/issues/8 and bring us closer to achieving https://github.com/Shyam-Sundar-Bharathi/cse210-tinyfoot-team14/issues/12.