### PR TITLE
fix: fix footnote inline problem and anchor filter regex

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,59 +3,43 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Your Page Title</title>
+    <title>History of Coffee with Footnotes</title>
     <script src="src/js/tinyfoot.js"></script>
     <link rel = "stylesheet" href="src/styles/tinyfoot.css">
     <link rel = "stylesheet" href="src/styles/tinyfoot-variables.css">
-    
+    <link rel = "stylesheet" href="src/styles/Variants/tinyfoot-number.css">
+
 </head>
 <body>
-    <p>
-        Here are some important footnotes:
-        <sup id="fnref:1">
-            <a href="#fn:1" rel="footnote">1</a>
-        </sup>
-    </p>
+
+    <h1>The Fascinating History of Coffee</h1>
+
+    <p>Coffee has a rich and storied history that dates back centuries. Its origin is often traced to <strong>Ethiopia</strong>, where legend has it that a goat herder named Kaldi discovered the coffee bean after noticing his goats became unusually energetic after eating the berries from a certain tree<sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup>. Word of this energizing fruit quickly spread throughout the region, and coffee cultivation and trade began in the Arabian Peninsula.</p>
+
+    <p>By the 15th century, coffee was being grown in the Yemeni district of Arabia and by the 16th century, it had spread to Persia, Egypt, Syria, and Turkey<sup id="fnref:2"><a href="#fn:2" rel="footnote">2</a></sup>. It was not only enjoyed in homes but also in the many public coffee houses, called <strong>qahveh khaneh</strong><sup id="fnref:3"><a href="#fn:3" rel="footnote">3</a></sup>, which began to appear in cities across the Middle East. Coffee houses quickly became centers of social activity and communication.</p>
+
+    <p>European travelers to the Near East brought back stories of an unusual dark black beverage. By the 17th century, coffee had made its way to Europe and was becoming popular across the continent<sup id="fnref:4"><a href="#fn:4" rel="footnote">4</a></sup>. Initially met with suspicion or fear—some calling it the "bitter invention of Satan"—it was eventually accepted when Pope Clement VIII purportedly blessed the drink<sup id="fnref:5"></sup><a href="#fn:5" rel="footnote">5</a></sup>. Coffee houses sprung up in major cities such as Venice, London, and Paris, serving as hubs for writers, artists, and intellectuals.</p>
+
+    <p>During this time, coffee began its global journey. The Dutch were the first to transport and cultivate coffee commercially, planting it in their colonies in Java (Indonesia). Soon after, the French began growing coffee in the Caribbean, and the Portuguese in Brazil<sup id="fnref:6"><a href="#fn:6" rel="footnote">6</a></sup>. These regions would go on to become some of the largest coffee producers in the world.</p>
+
+    <p>Today, coffee is a global commodity and one of the most consumed beverages, with over 2.25 billion cups consumed worldwide each day<sup id="fnref:7"><a href="#fn:7" rel="footnote">7</a></sup>.</p>
 
     <div class="footnotes">
         <ol>
-            <li class="footnote" id="fn:1">
-                <p>The current date and time is: <span id="current-date-time"></span><br>
-                Latest News:
-                <ul id="news-list"></ul>
-                <a href="#fnref:1" title="return to article"> ↩</a></p>
-            </li>
+            <li id="fn:1">According to legend, Kaldi observed his goats becoming more energetic after eating the coffee cherries, leading to the discovery of the stimulating effect of coffee. <a href="#fnref:1">↩</a></li>
+            <li id="fn:2">The spread of coffee cultivation in the Arabian Peninsula marked the beginning of coffee's role as a major trade commodity. <a href="#fnref:2">↩</a></li>
+            <li id="fn:3">The term "qahveh khaneh" refers to public coffee houses in the Middle East, which became gathering spots for intellectuals and social interactions. <a href="#fnref:3">↩</a></li>
+            <li id="fn:4">Coffee reached Europe through the ports of Venice, a major hub for trade between the East and West at the time. <a href="#fnref:4">↩</a></li>
+            <li id="fn:5">Pope Clement VIII reportedly tasted and approved of coffee in 1600, which helped remove its negative associations. <a href="#fnref:5">↩</a></li>
+            <li id="fn:6">The Dutch East India Company played a significant role in introducing coffee to Southeast Asia, especially the island of Java. <a href="#fnref:6">↩</a></li>
+            <li id="fn:7">Coffee is now a global industry with leading producers including Brazil, Vietnam, and Colombia. <a href="#fnref:7">↩</a></li>
         </ol>
     </div>
-
     <script>
-        function getCurrentDateTime() {
-            var currentDateTime = new Date();
-            return currentDateTime.toLocaleString();  // Formats date and time as a string
-        }
-
-        // Insert current date and time into the footnote
-        document.getElementById('current-date-time').textContent = getCurrentDateTime();
-
-        const newsHeadlines = [
-            "New AI breakthrough in healthcare industry.",
-            "Global markets rebound after initial slump.",
-            "Climate summit 2024 sees new policies introduced."
-        ];
-
-        function displayNews() {
-            const newsList = document.getElementById('news-list');
-            newsHeadlines.forEach((news) => {
-                var listItem = document.createElement('li');
-                listItem.textContent = news;
-                newsList.appendChild(listItem);
-            });
-        }
-        //calling the display news
-        displayNews();
-
-        // Initialize TinyFoot plugin
-        tinyfoot();
+        tinyfoot({
+            allowMultipleFN: true,
+            animationDuration: 500,
+        });
     </script>
 </body>
 </html>

--- a/src/js/tinyfoot.js
+++ b/src/js/tinyfoot.js
@@ -107,9 +107,9 @@
                 footnoteButton = replaceWithReferenceAttributes(footnoteButton, "SUP", relevantFNLink);
                 footnoteButton = replaceWithReferenceAttributes(footnoteButton, "FN", relevantFootnote);
                 
-                const footnoteButtonElem = document.createElement('div');
-                footnoteButtonElem.innerHTML = footnoteButton;
-                relevantFNLink.insertAdjacentElement('beforebegin', footnoteButtonElem);
+                const range = document.createRange();
+                const footnoteButtonElement = range.createContextualFragment(footnoteButton).firstElementChild;
+                relevantFNLink.insertAdjacentElement('beforebegin', footnoteButtonElement);
         
                 parent = relevantFootnote.parentElement;
         

--- a/src/js/tinyfoot.js
+++ b/src/js/tinyfoot.js
@@ -44,14 +44,13 @@
         const footnoteInit = () => {
             let curResetElement, currentLastFootnoteLink, footnoteAnchors, footnoteButton, lastResetElement, parent, relevantFNLink, relevantFootnote;
             let finalFNLinks = [], footnoteIDNum, footnoteLinks = [], footnotes = [], footnoteNum;
-            
+
             const footnoteButtonSearchQuery = settings.scope ? `${settings.scope} a[href*='#']` : "a[href*='#']";
-        
             footnoteAnchors = [...document.querySelectorAll(footnoteButtonSearchQuery)].filter(anchor => {
                 const relAttr = anchor.getAttribute("rel") || "";
                 const href = anchor.getAttribute("href") + relAttr;
                 const parentClass = anchor.closest(`[class*="${settings.footnoteParentClass}"]:not(a):not(${settings.anchorParentTagname})`);
-                return settings.anchorPattern.test(href) && !parentClass;
+                return href.match(settings.anchorPattern) && !parentClass;
             });
         
             cleanFootnoteLinks(footnoteAnchors, footnoteLinks);

--- a/src/js/tinyfoot.js
+++ b/src/js/tinyfoot.js
@@ -244,7 +244,6 @@
         };
         
         const clickButton = function(button) {
-            console.log('inside click button');
             let dataIdentifier;
             button.blur();
             dataIdentifier = `data-footnote-identifier='${button.getAttribute("data-footnote-identifier")}'`;
@@ -356,8 +355,6 @@
                     // Determine position (top or bottom)
                     let positionOnTop = roomLeft.bottomRoom < totalHeight && roomLeft.topRoom > roomLeft.bottomRoom;
                     let lastState = popoverStates[identifier];
-                    console.log('pos on top:',positionOnTop);
-                    console.log('lastState',lastState);
                     // Update classes and max heights
                     if (positionOnTop) {
                         if (lastState !== "top") {
@@ -413,7 +410,6 @@
                       
                         // Ensure maxWidth doesn't exceed the content width plus 1
                         const contentElement = thisElement.querySelector(".tinyfoot-footnote__content");
-                        console.log(contentElement.style);
                         maxWidth = Math.min(maxWidth, contentElement.offsetWidth + 1);
                       
                         // Set the max-width of the main wrapper
@@ -659,22 +655,19 @@
                         .replace(/\&ltsym\;/g, "&lt;");
                     
                     content = replaceWithReferenceAttributes(content, "BUTTON", button);
-                    console.log(content);
                 } finally {
                     // Create and configure the content element
                     const range = document.createRange();
                     const contentElement = range.createContextualFragment(content).firstElementChild; 
                     //content has "<aside>...</aside>"; contextual fragment creates a fragment out of the content string and firstelement generates ref to the actual element
                     //this method avoids creating a <div> and then adding content to its innerHTML
-                    console.log(contentElement);
                     try {
                         settings.activateCallback(contentElement, button);
-                    } catch (error) { console.log('hello')}
+                    } catch (error) {}
         
                     // Insert the contentElement after the button
                     button.insertAdjacentElement('afterend', contentElement);
                     popoverStates[button.getAttribute("data-footnote-identifier")] = "init";
-                    console.log(popoverStates);
                     const maxWidth = calculatePixelDimension(getComputedStyle(contentElement).maxWidth, contentElement);
                     contentElement.setAttribute("tinyfoot-max-width", maxWidth);
                     contentElement.style.maxWidth = "10000px"; // Set large max-width for animation


### PR DESCRIPTION
This PR fixed two issues:
- Footnotes not displayed correctly, a new `div` is created for each footnote.
- The regex for filtering footnote anchors is not working as expected.